### PR TITLE
[client] Add configuration to control autocommit behavior (Closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,19 @@ exec.setPigExecutionId(execId);
 // Write the metadata
 plugin.write(exec);
 ```
+
+
+
+Usage Notes
+-----------
+
+- If you have configuration variables already setup elsewhere, instead of using
+`NavigatorPlugin.fromConfigFile` you can use `NavigatorPlugin.fromConfigMap` and
+ pass in a `Map` of configurations.
+
+- By default, Navigator throttles its own internal committing process so that
+  new metadata won't be available immediately. For testing and development,
+  you can add a configuration variable "autocommit=true". However, it is very
+  strongly recommended that you do not use this in production in order to avoid
+  performance degradation and memory usage issues when running at scale.
+

--- a/client/src/main/java/com/cloudera/nav/sdk/client/PluginConfigurations.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/PluginConfigurations.java
@@ -37,6 +37,7 @@ public class PluginConfigurations {
   private Configuration hadoopConf;
   private Format format;
   private Map<String, Object> props;
+  private boolean autocommit;
 
   public PluginConfigurations() {
     props = Maps.newHashMap();
@@ -176,5 +177,13 @@ public class PluginConfigurations {
 
   public Object getProperty(String key) {
     return props.get(key);
+  }
+
+  public boolean isAutocommit() {
+    return autocommit;
+  }
+
+  public void setAutocommit(boolean autocommit) {
+    this.autocommit = autocommit;
   }
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/MClassWrapper.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/MClassWrapper.java
@@ -32,6 +32,7 @@ public class MClassWrapper {
 
   private final Map<String, Entity> entities;
   private final Map<String, Relation> relations;
+  private boolean autocommit;
 
   public MClassWrapper() {
     this.entities = Maps.newHashMap();
@@ -54,10 +55,6 @@ public class MClassWrapper {
     return relations.values();
   }
 
-  public boolean hasRelation(Relation r) {
-    return relations.containsKey(r.getIdentity());
-  }
-
   public void addRelation(Relation r) {
     relations.put(r.getIdentity(), r);
   }
@@ -66,5 +63,13 @@ public class MClassWrapper {
     for (Relation r : relations) {
       addRelation(r);
     }
+  }
+
+  public boolean isAutocommit() {
+    return autocommit;
+  }
+
+  public void setAutocommit(boolean autocommit) {
+    this.autocommit = autocommit;
   }
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
@@ -58,6 +58,7 @@ public abstract class MetadataWriter {
 
   public void write(Collection<Entity> entities) {
     MClassWrapper mclassWrapper = new MClassWrapper();
+    mclassWrapper.setAutocommit(config.isAutocommit());
     for (Entity entity : entities) {
       Preconditions.checkNotNull(entity);
       getAllMClasses(entity, mclassWrapper);
@@ -71,6 +72,7 @@ public abstract class MetadataWriter {
 
   public void writeRelations(Collection<Relation> relations) {
     MClassWrapper mClassWrapper = new MClassWrapper();
+    mClassWrapper.setAutocommit(config.isAutocommit());
     mClassWrapper.addRelations(relations);
     persistMetadataValues(mClassWrapper);
   }

--- a/client/src/test/resources/nav_plugin.conf
+++ b/client/src/test/resources/nav_plugin.conf
@@ -5,3 +5,8 @@ namespace=tf
 navigator_url=http://nav.cloudera.com:7187/api/v7/
 username=username
 password=password
+
+# Forces server to immediately make available newly written metadata.
+# Only use this for testing / development purposes. Usage in production is
+# NOT recommended and may cause performance and/or memory usage issues at scale
+autocommit=true


### PR DESCRIPTION
By default the Navigator server throttles the rate at which it makes
new metadata from the SDK available. For testing and development, the
user can set a configuration variable autocommit=true to force the
server to perform a full commit immediately so there's no lag from
running the client API call to when the metadata is searchable in
Navigator. This is NOT recommended for production use.

This is on top of PR #27 