### PR TITLE
[client] Expose server response

### DIFF
--- a/client/src/main/java/com/cloudera/nav/sdk/client/NavigatorPlugin.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/NavigatorPlugin.java
@@ -17,6 +17,7 @@ package com.cloudera.nav.sdk.client;
 
 import com.cloudera.nav.sdk.client.writer.MetadataWriter;
 import com.cloudera.nav.sdk.client.writer.MetadataWriterFactory;
+import com.cloudera.nav.sdk.client.writer.ResultSet;
 import com.cloudera.nav.sdk.model.entities.Entity;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -111,15 +112,15 @@ public class NavigatorPlugin {
    * Write the custom entity
    * @param entity
    */
-  public void write(Entity entity) {
-    write(ImmutableList.of(entity));
+  public ResultSet write(Entity entity) {
+    return write(ImmutableList.of(entity));
   }
 
   /**
    * Write a collection of custom entities
    * @param entities
    */
-  public void write(Collection<Entity> entities) {
+  public ResultSet write(Collection<Entity> entities) {
     MetadataWriter writer = factory.newWriter(config);
     try {
       writer.write(entities);
@@ -127,6 +128,7 @@ public class NavigatorPlugin {
     } finally {
       writer.close();
     }
+    return writer.getLastResultSet();
   }
 
   /**

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/JsonMetadataWriter.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/JsonMetadataWriter.java
@@ -38,18 +38,20 @@ import org.apache.commons.httpclient.HttpStatus;
 public class JsonMetadataWriter extends MetadataWriter {
 
   private final HttpURLConnection conn;
+  private final ObjectMapper mapper;
+  private ResultSet lastResult;
 
   public JsonMetadataWriter(PluginConfigurations config,
                             OutputStream stream,
                             HttpURLConnection conn) {
     super(config, stream);
     this.conn = conn;
+    this.mapper = newMapper();
   }
 
   @Override
   protected void persistMetadataValues(MClassWrapper mclassWrapper) {
     try {
-      ObjectMapper mapper = newMapper();
       mapper.writeValue(stream, mclassWrapper);
     } catch (IOException e) {
       Throwables.propagate(e);
@@ -78,8 +80,14 @@ public class JsonMetadataWriter extends MetadataWriter {
             "Error writing metadata (code %s): %s", conn.getResponseCode(),
             conn.getResponseMessage()));
       }
+      lastResult = mapper.readValue(conn.getInputStream(), ResultSet.class);
     } catch (IOException e) {
       Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public ResultSet getLastResultSet() {
+    return lastResult;
   }
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
@@ -102,6 +102,11 @@ public abstract class MetadataWriter {
     registry.reset();
   }
 
+  /**
+   * @return latest ResultSet from the most recent write operation
+   */
+  public abstract ResultSet getLastResultSet();
+
   private void getAllMClasses(Entity entity, MClassWrapper graph) {
     if (StringUtils.isEmpty(entity.getIdentity())) {
       entity.setIdentity(entity.generateId());

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/ResultSet.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/ResultSet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.client.writer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+
+import org.apache.commons.collections.CollectionUtils;
+
+/**
+ * Metadata writer results. Reports the number of entities and relations
+ * written and also any errors that occurred.
+ */
+public class ResultSet {
+
+  /**
+   * Count of new/updated metadata objects and also errors that occurred during
+   * processing
+   */
+  public static class UpdateWrapper {
+    private final int count;
+    private final Collection<String> errors;
+
+    @JsonCreator
+    public UpdateWrapper(@JsonProperty("count") int count,
+                         @JsonProperty("errors") Collection<String> errors) {
+      this.count = count;
+      this.errors = ImmutableList.copyOf(errors);
+    }
+
+    /**
+     * @return number of metadata entities successfully processed by the server
+     */
+    public int getCount() {
+      return count;
+    }
+
+    /**
+     * Errors occurred during metadata write
+     */
+    public Collection<String> getErrors() {
+      return errors;
+    }
+  }
+
+  private final UpdateWrapper entities;
+  private final UpdateWrapper relations;
+
+  @JsonCreator
+  public ResultSet(@JsonProperty("entities") UpdateWrapper entities,
+                   @JsonProperty("relations") UpdateWrapper relations) {
+    this.entities = entities;
+    this.relations = relations;
+  }
+
+  public UpdateWrapper getEntities() {
+    return entities;
+  }
+
+  public UpdateWrapper getRelations() {
+    return relations;
+  }
+
+
+  public boolean hasErrors() {
+    return (getEntities() != null && CollectionUtils.isNotEmpty(getEntities()
+        .getErrors())) || (getRelations() != null && CollectionUtils
+        .isNotEmpty(getRelations().getErrors()));
+  }
+
+  @Override
+  public String toString() {
+    String base = "\nRead %d %s.";
+    String rs = "";
+    if (getEntities() != null) {
+      rs += String.format(base, getEntities().getCount(), "entities");
+      if (CollectionUtils.isNotEmpty(getEntities().getErrors())) {
+        rs += "\nEntity errors (position : message) -\n" +
+            Joiner.on("\n").join(getEntities().getErrors());
+      }
+    }
+    if (getRelations() != null) {
+      rs += String.format(base, getRelations().getCount(), "relations");
+      if (CollectionUtils.isNotEmpty(getRelations().getErrors())) {
+        rs += "\nRelation errors (position : message) -\n" +
+            Joiner.on("\n").join(getRelations().getErrors());
+      }
+    }
+    return rs;
+  }
+}

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/lineage/CustomLineageCreator.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/lineage/CustomLineageCreator.java
@@ -17,6 +17,7 @@
 package com.cloudera.nav.sdk.examples.lineage;
 
 import com.cloudera.nav.sdk.client.NavigatorPlugin;
+import com.cloudera.nav.sdk.client.writer.ResultSet;
 
 import org.joda.time.Instant;
 
@@ -73,7 +74,11 @@ public class CustomLineageCreator {
     script.setIdentity(script.generateId());
     exec.setTemplate(script);
     // Write metadata
-    plugin.write(exec);
+    ResultSet results = plugin.write(exec);
+
+    if (results.hasErrors()) {
+      throw new RuntimeException(results.toString());
+    }
   }
 
   public String getPigOperationId() {
@@ -97,7 +102,6 @@ public class CustomLineageCreator {
     script.setPigOperation(getPigOperationId());
     script.setName("Stetson Script");
     script.setOwner("Chang");
-    script.setScript("LOAD GROUPBY AGGREGATE");
     script.setDescription("I am a custom operation template");
     return script;
   }

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/lineage/StetsonScript.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/lineage/StetsonScript.java
@@ -19,7 +19,6 @@ package com.cloudera.nav.sdk.examples.lineage;
 import com.cloudera.nav.sdk.model.CustomIdGenerator;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.cloudera.nav.sdk.model.annotations.MClass;
-import com.cloudera.nav.sdk.model.annotations.MProperty;
 import com.cloudera.nav.sdk.model.annotations.MRelation;
 import com.cloudera.nav.sdk.model.entities.EndPointProxy;
 import com.cloudera.nav.sdk.model.entities.Entity;
@@ -37,8 +36,6 @@ public class StetsonScript extends Entity {
 
   @MRelation(role = RelationRole.PHYSICAL)
   private EndPointProxy pigOperation;
-  @MProperty
-  private String script;
 
   public StetsonScript(String namespace) {
     // Because the namespace is given to input/output we ensure it
@@ -71,13 +68,6 @@ public class StetsonScript extends Entity {
   }
 
   /**
-   * The script contents in the custom DSL
-   */
-  public String getScript() {
-    return script;
-  }
-
-  /**
    * The StetsonScript is linked to a PIG operation via a Logical-Physical
    * relationship where the Pig operation is the PHYSICAL node
    */
@@ -88,9 +78,5 @@ public class StetsonScript extends Entity {
   public void setPigOperation(String pigOperationId) {
     this.pigOperation = new EndPointProxy(pigOperationId, SourceType.PIG,
         EntityType.OPERATION);
-  }
-
-  public void setScript(String script) {
-    this.script = script;
   }
 }

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/schema/FireCircleSchemaCreator.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/schema/FireCircleSchemaCreator.java
@@ -17,6 +17,7 @@
 package com.cloudera.nav.sdk.examples.schema;
 
 import com.cloudera.nav.sdk.client.NavigatorPlugin;
+import com.cloudera.nav.sdk.client.writer.ResultSet;
 import com.cloudera.nav.sdk.model.Source;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.cloudera.nav.sdk.model.entities.EntityType;
@@ -63,6 +64,11 @@ public class FireCircleSchemaCreator {
         new FireCircleField("col5", "date"),
         new FireCircleField("col6", "string")
     ));
-    plugin.write(dataset);
+    // Write metadata
+    ResultSet results = plugin.write(dataset);
+
+    if (results.hasErrors()) {
+      throw new RuntimeException(results.toString());
+    }
   }
 }

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHdfsFileTags.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHdfsFileTags.java
@@ -18,6 +18,7 @@ package com.cloudera.nav.sdk.examples.tags;
 
 import com.cloudera.nav.sdk.client.NavApiCient;
 import com.cloudera.nav.sdk.client.NavigatorPlugin;
+import com.cloudera.nav.sdk.client.writer.ResultSet;
 import com.cloudera.nav.sdk.model.Source;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.cloudera.nav.sdk.model.entities.EntityType;
@@ -47,6 +48,11 @@ public class SetHdfsFileTags {
     dir.setTags(Sets.newHashSet("HAS_SENSITIVE_FILES",
         "CONTAINS_SOME_SUPER_SECRET_STUFF"));
 
-    plugin.write(dir);
+    // Write metadata
+    ResultSet results = plugin.write(dir);
+
+    if (results.hasErrors()) {
+      throw new RuntimeException(results.toString());
+    }
   }
 }

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHiveTags.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHiveTags.java
@@ -18,6 +18,7 @@ package com.cloudera.nav.sdk.examples.tags;
 
 import com.cloudera.nav.sdk.client.NavApiCient;
 import com.cloudera.nav.sdk.client.NavigatorPlugin;
+import com.cloudera.nav.sdk.client.writer.ResultSet;
 import com.cloudera.nav.sdk.model.Source;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.cloudera.nav.sdk.model.entities.HiveColumn;
@@ -50,6 +51,11 @@ public class SetHiveTags {
     Source hive = client.getOnlySource(SourceType.HIVE);
     column.setSourceId(hive.getIdentity());
 
-    plugin.write(column);
+    // Write metadata
+    ResultSet results = plugin.write(column);
+
+    if (results.hasErrors()) {
+      throw new RuntimeException(results.toString());
+    }
   }
 }


### PR DESCRIPTION
Deserialize the metadata server response as a ResultSet object that is returned
by NavigatorPlugin.write. Modify examples so if any error messages are present,
an exception is thrown with the error messages.

Closes #19 and #25 