### PR TITLE
[model][client] Custom metadata model registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,30 @@ plugin.write(exec);
 
 
 
+Creating Managed Metadata Models
+--------------------------------
+
+Cloudera Navigator 2.6.0 added the ability to create manage metadata fields.
+Managed metadata is a more organized way to extend metadata properties collected
+by Navigator. Managed metadata properties must be declared with a type
+constraint on the value(s), must belong to a namespace, and can be associated
+with 0 or more metadata classes.
+
+The SDK client is configured with a namespace that's used for all declared
+managed metadata properties. It is also the package name for all custom metadata
+classes. Just as a reminder, a custom metadata class can be created by
+subclassing Entity with an @MClass annotation.
+
+New metadata properties for custom metadata classes are created using the
+@MProperty annotation. In this new version of the SDK, we've added new
+attributes to the annotation to make it easier to register managed metadata
+properties. In order to create a managed property, set the `register` attribute
+to `true`. You can then set `fieldType` (default `TEXT`), `pattern` for regex
+matching, `maxLength` for `TEXT` fields, or an array of `values` for `ENUM`
+properties. The examples have been updated to demonstrate this new capability.
+
+
+
 Usage Notes
 -----------
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -8,3 +8,5 @@ along side the compatible Navigator versions.
 | SDK Version | Minimum Navigator Version | Maximum Navigator Version |
 |-------------|---------------------------|---------------------------|
 | 1.0         | 2.4.0                     |                           |
+|-------------|---------------------------|---------------------------|
+| 2.0         | 2.6.0                     |                           |

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -51,6 +51,11 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.9</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/client/src/main/java/com/cloudera/nav/sdk/client/ClientConfig.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/ClientConfig.java
@@ -15,13 +15,8 @@
  */
 package com.cloudera.nav.sdk.client;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.TrustManager;
-
-import org.apache.hadoop.conf.Configuration;
 
 /**
  * A set of configuration options needed by the Navigator plugin
@@ -29,12 +24,11 @@ import org.apache.hadoop.conf.Configuration;
 public class ClientConfig {
 
   private String navigatorUrl;
-  private URI metadataParentUri;
+  private int apiVersion;
   private String applicationUrl;
   private String namespace;
   private String username;
   private String password;
-  private Configuration hadoopConf;
   private Format format;
   private boolean autocommit;
   private boolean disableSSLValidation;
@@ -45,54 +39,35 @@ public class ClientConfig {
   private String sslTrustStorePassword;
 
   /**
-   * @return Location of the Navigator API server
+   * @return Location of Navigator
    */
   public String getNavigatorUrl() {
     return navigatorUrl;
   }
 
   /**
-   * Sets the URL for the Navigator API server
-   * @param navigatorUrl new URL for Navigator API server
+   * Sets the URL for Navigator
+   * @param navigatorUrl new URL for Navigator
    */
   public void setNavigatorUrl(String navigatorUrl) {
     this.navigatorUrl = navigatorUrl;
   }
 
   /**
-   * @return URI for the parent under which metadata will be written
+   * Return the Navigator API version number. For publishing metadata to
+   * Navigator 7 is the minimum required. For creating managed custom properties
+   * 9 is the minimum required.
    */
-  public URI getMetadataParentUri() {
-    return metadataParentUri;
+  public int getApiVersion() {
+    return apiVersion;
   }
 
   /**
-   * @return String representation of the metadata parent URI
+   * Set the Navigator API version number
+   * @param apiVersion
    */
-  public String getMetadataParentUriString() {
-    return metadataParentUri.toString();
-  }
-
-  /**
-   * Change the metadata parent location. An URISyntaxException is
-   * thrown if the given String is an invalid URI.
-   * @param metadataParent
-   */
-  public void setMetadataParentUri(String metadataParent)
-      throws URISyntaxException {
-    // for local file paths
-    if (metadataParent.startsWith("/")) {
-      metadataParent = "file://" + metadataParent;
-    }
-    setMetadataParentUri(new URI(metadataParent));
-  }
-
-  /**
-   * Change the metadata parent location
-   * @param metadataParent
-   */
-  public void setMetadataParentUri(URI metadataParent) {
-    this.metadataParentUri = metadataParent;
+  public void setApiVersion(int apiVersion) {
+    this.apiVersion = apiVersion;
   }
 
   /**
@@ -144,17 +119,6 @@ public class ClientConfig {
 
   public void setApplicationUrl(String applicationUrl) {
     this.applicationUrl = applicationUrl;
-  }
-
-  /**
-   * @return the hadoop configurations used to create a connection to HDFS
-   */
-  public Configuration getHadoopConfigurations() {
-    return hadoopConf;
-  }
-
-  public void setHadoopConfigurations(Configuration conf) {
-    this.hadoopConf = conf;
   }
 
   /**

--- a/client/src/main/java/com/cloudera/nav/sdk/client/ClientConfigFactory.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/ClientConfigFactory.java
@@ -18,7 +18,6 @@ package com.cloudera.nav.sdk.client;
 
 import com.google.common.base.Throwables;
 
-import java.net.URI;
 import java.util.Map;
 
 import org.apache.commons.configuration.ConfigurationException;
@@ -32,9 +31,9 @@ public class ClientConfigFactory {
   // expected property names
   public static final String APP_URL = "application_url";
   public static final String FILE_FORMAT = "file_format";
-  public static final String METADATA_URI = "metadata_parent_uri";
   public static final String NAMESPACE = "namespace";
   public static final String NAV_URL = "navigator_url";
+  public static final String API_VERSION = "navigator_api_version";
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
   public static final String AUTOCOMMIT = "autocommit";
@@ -56,9 +55,9 @@ public class ClientConfigFactory {
       config.setApplicationUrl(props.getString(APP_URL));
       config.setFormat(Format.valueOf(
           props.getString(FILE_FORMAT, Format.JSON.name())));
-      config.setMetadataParentUri(URI.create(props.getString(METADATA_URI)));
       config.setNamespace(props.getString(NAMESPACE));
       config.setNavigatorUrl(props.getString(NAV_URL));
+      config.setApiVersion(props.getInt(API_VERSION));
       config.setUsername(props.getString(USERNAME));
       config.setPassword(props.getString(PASSWORD));
       config.setAutocommit(props.getBoolean(AUTOCOMMIT, false));
@@ -81,9 +80,9 @@ public class ClientConfigFactory {
         Format.valueOf(props.get(FILE_FORMAT).toString()) :
         Format.JSON;
     config.setFormat(format);
-    config.setMetadataParentUri(URI.create(props.get(METADATA_URI).toString()));
     config.setNamespace(props.get(NAMESPACE).toString());
     config.setNavigatorUrl(props.get(NAV_URL).toString());
+    config.setApiVersion((int)props.get(API_VERSION));
     config.setUsername(props.get(USERNAME).toString());
     config.setPassword(props.get(PASSWORD).toString());
     config.setAutocommit(props.containsKey(AUTOCOMMIT) ?

--- a/client/src/main/java/com/cloudera/nav/sdk/client/ConnectionType.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/ConnectionType.java
@@ -14,26 +14,14 @@
  * limitations under the License.
  */
 
-package com.cloudera.nav.sdk.model;
+package com.cloudera.nav.sdk.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-import org.junit.Test;
-
-public class MD5IdGeneratorTest {
-
-  @Test
-  public void testBasic() {
-    String hash = MD5IdGenerator.generateIdentity("foo");
-    assertEquals(MD5IdGenerator.generateIdentity("foo"), hash);
-    assertNotEquals(MD5IdGenerator.generateIdentity("bar"), hash);
-    assertEquals(hash.length(), 32);
-  }
-
-  @Test
-  public void testPig() {
-    String hash = MD5IdGenerator.generateIdentity(
-        "PigLatin:", "");
-  }
+/**
+ * Indicates how the metadata is written.
+ * FILE means writing to the local file system
+ * HDFS means writing to an HDFS file
+ * HTTP means writing to Navigator server (includes HTTPS)
+ */
+public enum ConnectionType {
+  FILE,HDFS,HTTP
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/NavApiCient.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/NavApiCient.java
@@ -15,6 +15,7 @@
  */
 package com.cloudera.nav.sdk.client;
 
+import com.cloudera.nav.sdk.model.MetadataModel;
 import com.cloudera.nav.sdk.model.Source;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.google.common.annotations.VisibleForTesting;
@@ -74,10 +75,29 @@ public class NavApiCient {
   /**
    * Registers a given set of metadata models
    *
-   * @param models
+   * @param model
    */
-  public void registerModels(Collection<Object> models) {
-    throw new UnsupportedOperationException("not yet implemented");
+  public MetadataModel registerModels(MetadataModel model) {
+    String url = joinUrlPath(getApiUrl(), "models");
+    return sendRequest(url, HttpMethod.POST, MetadataModel.class, model);
+  }
+
+  private <T> T sendRequest(String url, HttpMethod method,
+                            Class<? extends T> resultClass) {
+    return sendRequest(url, method, resultClass, null);
+  }
+
+  private <R, T> T sendRequest(String url, HttpMethod method,
+                               Class<? extends T> resultClass,
+                               R requestPayload) {
+    RestTemplate restTemplate = newRestTemplate();
+        HttpHeaders headers = getAuthHeaders();
+    HttpEntity<?> request = requestPayload == null ?
+        new HttpEntity<String>(headers) :
+        new HttpEntity<>(requestPayload, headers);
+    ResponseEntity<? extends T> response = restTemplate.exchange(url, method,
+        request, resultClass);
+    return response.getBody();
   }
 
   /**
@@ -85,15 +105,13 @@ public class NavApiCient {
    *
    * @return a collection of available sources
    */
-  public Collection<Source> getAllSources() {
-    RestTemplate restTemplate = newRestTemplate();
-    String url = getUrl();
-    HttpHeaders headers = getAuthHeaders();
-    HttpEntity<String> request = new HttpEntity<String>(headers);
-    ResponseEntity<SourceAttrs[]> response = restTemplate.exchange(url,
-        HttpMethod.GET, request, SourceAttrs[].class);
-    Collection<Source> sources = Lists.newArrayList();
-    for (SourceAttrs info : response.getBody()) {
+  public Collection<Source> getAllSources () {
+        String url = entitiesQueryUrl();
+    SourceAttrs[] sourceAttrs = sendRequest(url, HttpMethod.GET,
+        SourceAttrs[].class);
+    Collection<Source> sources = Lists.newArrayListWithExpectedSize(sourceAttrs
+        .length + 1);
+    for (SourceAttrs info : sourceAttrs) {
       sources.add(info.createSource());
     }
     return sources;
@@ -109,8 +127,9 @@ public class NavApiCient {
    */
   public ResultsBatch<Map<String, Object>> getRelationBatch(
       MetadataQuery metadataQuery) {
-    String fullUrlPost = getUrl("relations");
-    return queryNav(fullUrlPost, metadataQuery, RelationResultsBatch.class);
+    String fullUrlPost = pagingUrl("relations");
+    return sendRequest(fullUrlPost, HttpMethod.POST, RelationResultsBatch.class,
+        metadataQuery);
   }
 
   /**
@@ -118,33 +137,13 @@ public class NavApiCient {
    */
   public ResultsBatch<Map<String, Object>> getEntityBatch(
       MetadataQuery metadataQuery) {
-    String fullUrlPost = getUrl("entities");
-    return queryNav(fullUrlPost, metadataQuery, EntityResultsBatch.class);
+    String fullUrlPost = pagingUrl("entities");
+    return sendRequest(fullUrlPost, HttpMethod.POST, EntityResultsBatch.class,
+        metadataQuery);
   }
 
-  /**
-   * Constructs a POST Request from the given URL and body and returns the
-   * response body contains a batch of results.
-   *
-   * @param url           URl being posted to
-   * @param metadataQuery query criteria for metadata being retrieved to satisfy
-   * @param resultClass   type of ResultsBatch to be returned
-   * @return ResultsBatch of entities or relations that specify the
-   * query parameters in the URL and request body
-   */
   @VisibleForTesting
-  public ResultsBatch<Map<String, Object>> queryNav(String url,
-                                                    MetadataQuery metadataQuery,
-                                                    Class<? extends ResultsBatch<Map<String, Object>>> resultClass) {
-    RestTemplate restTemplate = newRestTemplate();
-    HttpHeaders headers = getAuthHeaders();
-    HttpEntity<MetadataQuery> request =
-        new HttpEntity<MetadataQuery>(metadataQuery, headers);
-    return restTemplate.exchange(url, HttpMethod.POST, request,
-        resultClass).getBody();
-  }
-
-  private RestTemplate newRestTemplate() {
+  RestTemplate newRestTemplate() {
     if (isSSL) {
       CloseableHttpClient httpClient = HttpClients.custom()
           .setSSLContext(sslContext)
@@ -229,15 +228,20 @@ public class NavApiCient {
   /**
    * @return url for querying all sources
    */
-  private String getUrl() {
+  private String entitiesQueryUrl() {
     // form the url string to request all entities with type equal to SOURCE
-    String baseNavigatorUrl = config.getNavigatorUrl();
+    String baseNavigatorUrl = getApiUrl();
     String entitiesUrl = joinUrlPath(baseNavigatorUrl, "entities");
     return String.format("%s?query=%s", entitiesUrl, SOURCE_QUERY);
   }
 
-  private String getUrl(String type) {
-    String baseNavigatorUrl = config.getNavigatorUrl();
+  String getApiUrl() {
+    return joinUrlPath(config.getNavigatorUrl(),
+        "/api/v" + String.valueOf(config.getApiVersion()));
+  }
+
+  private String pagingUrl(String type) {
+    String baseNavigatorUrl = getApiUrl();
     String typeUrl = joinUrlPath(baseNavigatorUrl, type);
     return typeUrl + "/paging";
   }
@@ -269,6 +273,14 @@ public class NavApiCient {
   }
 
   private static String joinUrlPath(String base, String component) {
-    return base + (base.endsWith("/") ? "" : "/") + component;
+    boolean baseSlash = base.endsWith("/");
+    boolean componentSlash = component.startsWith("/");
+    if (baseSlash && componentSlash) {
+      return base + component.substring(1);
+    } else if (baseSlash || componentSlash) {
+      return base + component;
+    } else {
+      return base + "/" + component;
+    }
   }
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/NavigatorPlugin.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/NavigatorPlugin.java
@@ -18,14 +18,23 @@ package com.cloudera.nav.sdk.client;
 import com.cloudera.nav.sdk.client.writer.MetadataWriter;
 import com.cloudera.nav.sdk.client.writer.MetadataWriterFactory;
 import com.cloudera.nav.sdk.client.writer.ResultSet;
+import com.cloudera.nav.sdk.model.MetadataModel;
+import com.cloudera.nav.sdk.model.MetadataModelFactory;
+import com.cloudera.nav.sdk.model.annotations.MClass;
 import com.cloudera.nav.sdk.model.entities.Entity;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Communicates with Navigator to register custom entity models and
@@ -33,6 +42,9 @@ import org.apache.commons.lang.StringUtils;
  * information
  */
 public class NavigatorPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NavigatorPlugin
+      .class);
 
   /**
    * Use the information contained in the given configuration file to
@@ -66,8 +78,10 @@ public class NavigatorPlugin {
    */
   public NavigatorPlugin(ClientConfig config,
                          MetadataWriterFactory factory) {
-    Preconditions.checkArgument(!StringUtils.isEmpty(config.getNavigatorUrl()));
-    Preconditions.checkArgument(config.getMetadataParentUri() != null);
+    Preconditions.checkArgument(!StringUtils.isEmpty(config.getNavigatorUrl()),
+        "No Navigator URL configured");
+    Preconditions.checkArgument(config.getApiVersion() >= 7,
+        "Minimum API version supported is v7 for writing to Navigator");
     Preconditions.checkNotNull(factory);
     this.config = config;
     this.factory = factory;
@@ -92,8 +106,23 @@ public class NavigatorPlugin {
    * in the given package. Registers all found classes with Navigator
    * @param packageName
    */
-  public void registerModels(String packageName) {
-    throw new UnsupportedOperationException();
+  @SuppressWarnings("unchecked")
+  public MetadataModel registerModels(String packageName) {
+    Reflections ref = new Reflections(packageName + ".");
+    Set<Class<?>> types = ref.getTypesAnnotatedWith(MClass.class);
+    Collection<Class<Entity>> modelClasses = Lists.newArrayListWithExpectedSize(
+        types.size() + 1);
+    for (Class<?> aClass : types) {
+      Preconditions.checkArgument(Entity.class.isAssignableFrom(aClass));
+      modelClasses.add((Class<Entity>)aClass);
+    }
+    if (modelClasses.size() > 0) {
+      LOG.info("Registering models: {}", modelClasses);
+      return registerModels(modelClasses);
+    } else {
+      LOG.info("No models to be registered in package {}", packageName);
+      return null;
+    }
   }
 
   /**
@@ -104,8 +133,17 @@ public class NavigatorPlugin {
    * annotation
    * @param entityClass
    */
-  public void registerModel(Class<? extends Entity> entityClass) {
-    throw new UnsupportedOperationException();
+  public MetadataModel registerModel(Class<? extends Entity> entityClass) {
+    return registerModels(Collections.singleton(entityClass));
+  }
+
+  public MetadataModel registerModels(
+      Collection<? extends Class<? extends Entity>> classes) {
+    Preconditions.checkArgument(config.getApiVersion() >= 9,
+        "Model registration not supported by API earlier than v9");
+    MetadataModelFactory factory = new MetadataModelFactory();
+    MetadataModel model = factory.newModel(classes, getConfig().getNamespace());
+    return getClient().registerModels(model);
   }
 
   /**

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/JsonMetadataWriter.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/JsonMetadataWriter.java
@@ -18,6 +18,7 @@ package com.cloudera.nav.sdk.client.writer;
 
 import com.cloudera.nav.sdk.client.ClientConfig;
 import com.cloudera.nav.sdk.client.writer.serde.EntitySerializer;
+import com.cloudera.nav.sdk.client.writer.serde.EntityV9Serializer;
 import com.cloudera.nav.sdk.client.writer.serde.RelationSerializer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -63,7 +64,11 @@ public class JsonMetadataWriter extends MetadataWriter {
   private ObjectMapper newMapper() {
     ObjectMapper mapper = new ObjectMapper();
     SimpleModule module = new SimpleModule("MetadataSerializer");
-    module.addSerializer(new EntitySerializer(registry));
+    if (config.getApiVersion() < 9) {
+      module.addSerializer(new EntitySerializer(registry));
+    } else {
+      module.addSerializer(new EntityV9Serializer(registry));
+    }
     module.addSerializer(new RelationSerializer(registry));
     mapper.registerModule(module);
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/MetadataWriter.java
@@ -44,7 +44,7 @@ public abstract class MetadataWriter {
   public MetadataWriter(ClientConfig config, OutputStream stream) {
     this.config = config;
     this.stream = stream;
-    registry = new MClassRegistry();
+    registry = new MClassRegistry(config.getNamespace());
   }
 
   /**

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/registry/MClassRegistry.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/registry/MClassRegistry.java
@@ -38,10 +38,14 @@ public class MClassRegistry {
       propertyRegistry;
   private final LoadingCache<Class<?>, Collection<MRelationEntry>>
       relationRegistry;
+  private final String namespace;
 
-  public MClassRegistry() {
+  public MClassRegistry(String namespace) {
+    Preconditions.checkArgument(StringUtils.isNotEmpty(namespace),
+        "Must supply non-empty namespace identifying client application");
     propertyRegistry = (new MPropertyEntryFactory()).newRegistry();
     relationRegistry = (new MRelationEntryFactory()).newRegistry();
+    this.namespace = namespace;
   }
 
   /**
@@ -103,5 +107,9 @@ public class MClassRegistry {
                 prop.getName()));
       }
     }
+  }
+
+  public String getNamespace() {
+    return namespace;
   }
 }

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/EntitySerializer.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/EntitySerializer.java
@@ -23,6 +23,11 @@ import com.fasterxml.jackson.core.JsonGenerator;
 
 import java.io.IOException;
 
+/**
+ * JSON serializer for Entity instances for API < v9.
+ * MProperty's are written as key-value pairs and we also automatically add
+ * internalType needed by the server
+ */
 public class EntitySerializer extends MClassSerializer<Entity> {
 
   public EntitySerializer(MClassRegistry registry) {

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/EntityV9Serializer.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/EntityV9Serializer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.client.writer.serde;
+
+import com.cloudera.nav.sdk.client.writer.registry.MClassRegistry;
+import com.cloudera.nav.sdk.client.writer.registry.MPropertyEntry;
+import com.cloudera.nav.sdk.model.annotations.MClass;
+import com.cloudera.nav.sdk.model.annotations.MProperty;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.Maps;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.collections.MapUtils;
+
+/**
+ * JSON serializer for Entity instances. It writes managed custom properties
+ * with their specified value types, into a 'customProperties' map attribute.
+ * Remaining MProperty's are written as key-value pairs.
+ * We also automatically add internalType and metaClassName attributes needed
+ * by the server to map the meta-model
+ */
+public class EntityV9Serializer extends EntitySerializer {
+  public EntityV9Serializer(MClassRegistry registry) {
+    super(registry);
+  }
+
+  @Override
+  protected void writeProperties(Entity t, JsonGenerator jg) throws IOException {
+    Map<String, Map<String, Object>> customProperties = Maps.newHashMap();
+    for (MPropertyEntry p : registry.getProperties(t.getClass())) {
+      MProperty ann = p.getAnnotation();
+      if (ann.register()) {
+        addCustom(customProperties, p, t);
+      } else {
+        Object v = p.getValue(t);
+        if (v != null) {
+          jg.writeObjectField(p.getAttribute(), p.getValue(t));
+        }
+      }
+    }
+    String modelName = t.getClass().getAnnotation(MClass.class).model();
+    jg.writeStringField("internalType", modelName);
+
+    jg.writeStringField("metaClassName", modelName);
+    if (MapUtils.isNotEmpty(customProperties)) {
+      jg.writeObjectField("customProperties", customProperties);
+    }
+  }
+
+  private void addCustom(Map<String, Map<String, Object>> customProperties,
+                         MPropertyEntry prop, Entity t) {
+    String namespace = registry.getNamespace();
+    Map<String, Object> propMap = customProperties.get(namespace);
+    if (propMap == null) {
+      propMap = Maps.newHashMap();
+      customProperties.put(namespace, propMap);
+    }
+    propMap.put(prop.getAttribute(), prop.getValue(t));
+  }
+}

--- a/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/MClassSerializer.java
+++ b/client/src/main/java/com/cloudera/nav/sdk/client/writer/serde/MClassSerializer.java
@@ -24,9 +24,13 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import java.io.IOException;
 
+/**
+ * JSON serializer for MClass objects, which writes out an object
+ * containing the MProperty entries as key-value pairs
+ */
 public class MClassSerializer<T> extends StdSerializer<T> {
 
-  private final MClassRegistry registry;
+  protected final MClassRegistry registry;
 
   public MClassSerializer(Class<T> aClass, MClassRegistry registry) {
     super(aClass);

--- a/client/src/test/java/com/cloudera/nav/sdk/client/NavigatorPluginTest.java
+++ b/client/src/test/java/com/cloudera/nav/sdk/client/NavigatorPluginTest.java
@@ -16,23 +16,32 @@
 
 package com.cloudera.nav.sdk.client;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import com.cloudera.nav.sdk.client.writer.MetadataWriter;
 import com.cloudera.nav.sdk.client.writer.MetadataWriterFactory;
+import com.cloudera.nav.sdk.model.MetadataModel;
+import com.cloudera.nav.sdk.model.annotations.MClass;
 import com.cloudera.nav.sdk.model.entities.Entity;
 import com.cloudera.nav.sdk.model.entities.HdfsEntity;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.*;
+import org.junit.runner.*;
 import org.mockito.*;
 import org.mockito.runners.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NavigatorPluginTest {
@@ -41,20 +50,22 @@ public class NavigatorPluginTest {
   private MetadataWriterFactory mockFactory;
   @Captor
   private ArgumentCaptor<Collection<Entity>> captor;
+  private ClientConfig config;
+  private NavigatorPlugin plugin;
 
   @Before
   public void setUp() {
     mockWriter = mock(MetadataWriter.class);
     mockFactory = mock(MetadataWriterFactory.class);
     doReturn(mockWriter).when(mockFactory).newWriter();
+    URL url = this.getClass().getClassLoader().getResource("nav_plugin.conf");
+    ClientConfigFactory factory = new ClientConfigFactory();
+    config = factory.readConfigurations(url.getPath());
+    plugin = spy(new NavigatorPlugin(config, mockFactory));
   }
 
   @Test
   public void testWrite() {
-    URL url = this.getClass().getClassLoader().getResource("nav_plugin.conf");
-    ClientConfigFactory factory = new ClientConfigFactory();
-    ClientConfig config = factory.readConfigurations(url.getPath());
-    NavigatorPlugin plugin = new NavigatorPlugin(config, mockFactory);
     HdfsEntity entity = new HdfsEntity();
     entity.setIdentity("foo");
     plugin.write(entity);
@@ -62,5 +73,41 @@ public class NavigatorPluginTest {
     assertEquals(Iterables.getOnlyElement(captor.getValue()), entity);
     verify(mockWriter).flush();
     verify(mockWriter).close();
+  }
+
+  @Test
+  public void testRegisterModels() {
+    assertModelRegistration();
+  }
+
+  private void assertModelRegistration() {
+    RestTemplate mockTemplate = mock(RestTemplate.class);
+    NavApiCient client = spy(plugin.getClient());
+    when(plugin.getClient()).thenReturn(client);
+    when(client.newRestTemplate()).thenReturn(mockTemplate);
+    MetadataModel mockResponse = new MetadataModel();
+    Map<String, Collection<String>> mockErrs = Maps.newHashMap();
+    mockErrs.put("model1", Sets.newHashSet("msg1", "msg2"));
+    when(mockTemplate.exchange(eq(plugin.getClient().getApiUrl() + "/models"),
+        eq(HttpMethod.POST), any(HttpEntity.class), eq(MetadataModel.class)))
+        .thenReturn(new ResponseEntity<>(mockResponse, HttpStatus.OK));
+    MetadataModel response = plugin.registerModel(TestMClass.class);
+    assertEquals(mockResponse, response);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testRegisterModelsError() {
+    // v7 doesn't support model registration
+    config.setApiVersion(7);
+    plugin = spy(new NavigatorPlugin(config, mockFactory));
+    assertModelRegistration();
+  }
+
+  @MClass(model="test")
+  private static class TestMClass extends Entity {
+    @Override
+    public String generateId() {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/client/src/test/java/com/cloudera/nav/sdk/client/PluginConfigurationFactoryTest.java
+++ b/client/src/test/java/com/cloudera/nav/sdk/client/PluginConfigurationFactoryTest.java
@@ -32,11 +32,9 @@ public class PluginConfigurationFactoryTest {
 
     assertEquals(config.getApplicationUrl(), "http://external-app.com");
     assertEquals(config.getFormat(), Format.JSON);
-    assertEquals(config.getMetadataParentUri().toString(),
-        "http://nav.cloudera.com:7187/api/v7/plugin");
     assertEquals(config.getNamespace(), "tf");
     assertEquals(config.getNavigatorUrl(),
-        "http://nav.cloudera.com:7187/api/v7/");
+        "http://nav.cloudera.com:7187");
     assertEquals(config.getUsername(), "username");
     assertEquals(config.getPassword(), "password");
   }

--- a/client/src/test/java/com/cloudera/nav/sdk/client/SSLUtilsTest.java
+++ b/client/src/test/java/com/cloudera/nav/sdk/client/SSLUtilsTest.java
@@ -50,11 +50,11 @@ public class SSLUtilsTest {
   public void setUp() throws Exception {
     Map<String, Object> confMap = Maps.newHashMap();
     confMap.put(ClientConfigFactory.APP_URL, "localhost");
-    confMap.put(ClientConfigFactory.METADATA_URI, "localhost");
     confMap.put(ClientConfigFactory.NAV_URL, "localhost");
     confMap.put(ClientConfigFactory.NAMESPACE, "test");
     confMap.put(ClientConfigFactory.USERNAME, "user");
     confMap.put(ClientConfigFactory.PASSWORD, "pass");
+    confMap.put(ClientConfigFactory.API_VERSION, 9);
     config = (new ClientConfigFactory()).fromConfigMap(confMap);
 
     KeyStore keyStore = KeyStore.getInstance("jks");

--- a/client/src/test/java/com/cloudera/nav/sdk/client/writer/registry/MClassRegistryTest.java
+++ b/client/src/test/java/com/cloudera/nav/sdk/client/writer/registry/MClassRegistryTest.java
@@ -32,7 +32,7 @@ public class MClassRegistryTest {
 
   @Before
   public void setUp() {
-    registry = new MClassRegistry();
+    registry = new MClassRegistry("namespace");
     mclassObj = new MetadataClass();
     mclassObj.setIdentity("id");
     mclassObj.setSourceType(SourceType.HDFS);

--- a/client/src/test/resources/nav_plugin.conf
+++ b/client/src/test/resources/nav_plugin.conf
@@ -1,8 +1,7 @@
 application_url=http://external-app.com
-file_format=JSON
-metadata_parent_uri=http://nav.cloudera.com:7187/api/v7/plugin
 namespace=tf
-navigator_url=http://nav.cloudera.com:7187/api/v7/
+navigator_url=http://nav.cloudera.com:7187
+navigator_api_version=9
 username=username
 password=password
 

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/CustomLineageCreator.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/CustomLineageCreator.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.cloudera.nav.sdk.examples.lineage;
+package com.cloudera.nav.sdk.examples.managed;
 
 import com.cloudera.nav.sdk.client.NavigatorPlugin;
 import com.cloudera.nav.sdk.client.writer.ResultSet;
@@ -22,26 +22,12 @@ import com.cloudera.nav.sdk.client.writer.ResultSet;
 import org.joda.time.Instant;
 
 /**
- * In this example we show how to create custom entity types and
- * how to link them to hadoop entities. We define a custom operation entity
- * from a hypothetical application called Stetson. The Stetson application
- * defines a custom operations called StetsonScript and a custom operation
- * execution entity called StetsonExecution. A StetsonScript is the template
- * for a StetsonExecution and so we use the @MRelation annotation to specify an
- * InstanceOf relationship between the StetsonExecution and StetsonScript.
+ * In this example we extend the lineage example to show how to create managed
+ * metadata properties. For more details on the base example, please see
+ * {@link com.cloudera.nav.sdk.examples.lineage.CustomLineageCreator}.
  *
- * In Hadoop, Stetson operations are carried out using Pig. In order to
- * establish the relationship between the Stetson custom entities and the
- * hadoop entities, we again use the @MRelation annotation to form
- * LogicalPhysical relationships.
- *
- * Relations created:
- *
- * StetsonScript ---(LogicalPhysical)---> Pig Operation
- * StetsonExecution ---(LogicalPhysical)---> Pig Execution
- *
- * The relationships between Pig operation and execution are created
- * automatically by Navigator
+ * In this example, we've created several managed properties in the
+ * `StetsonExecution` classes using the `register` attribute in `@MProperty`
  */
 public class CustomLineageCreator {
 
@@ -75,6 +61,21 @@ public class CustomLineageCreator {
     // Connect the template and instance
     script.setIdentity(script.generateId());
     exec.setTemplate(script);
+
+    // Bad steward field, does not match regex
+    exec.setSteward("foo");
+    assert plugin.write(exec).hasErrors();
+
+    // correct steward
+    exec.setSteward("chang@company.com");
+
+    // Bad group
+    exec.setGroup("Random Group");
+    assert plugin.write(exec).hasErrors();
+
+    // correct group
+    exec.setGroup(StetsonExecution.INFRA);
+
     // Write metadata
     ResultSet results = plugin.write(exec);
 
@@ -115,7 +116,6 @@ public class CustomLineageCreator {
     exec.setDescription("I am a custom operation instance");
     exec.setLink("http://hasthelargehadroncolliderdestroyedtheworldyet.com/");
     exec.setIndex(10);
-    exec.setSteward("chang");
     exec.setStarted(Instant.now());
     exec.setEnded((new Instant(Instant.now().toDate().getTime() + 10000)));
     return exec;

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/StetsonExecution.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/StetsonExecution.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.cloudera.nav.sdk.examples.lineage;
+package com.cloudera.nav.sdk.examples.managed;
 
 import com.cloudera.nav.sdk.model.CustomIdGenerator;
 import com.cloudera.nav.sdk.model.SourceType;
 import com.cloudera.nav.sdk.model.annotations.MClass;
 import com.cloudera.nav.sdk.model.annotations.MProperty;
 import com.cloudera.nav.sdk.model.annotations.MRelation;
+import com.cloudera.nav.sdk.model.custom.CustomPropertyType;
 import com.cloudera.nav.sdk.model.entities.EndPointProxy;
 import com.cloudera.nav.sdk.model.entities.Entity;
 import com.cloudera.nav.sdk.model.entities.EntityType;
@@ -37,6 +38,10 @@ import org.joda.time.Instant;
 @MClass(model = "stetson_exec")
 public class StetsonExecution extends Entity {
 
+  public static final String INFRA = "INFRA";
+  public static final String DATA_ENG = "DATA_ENG";
+  public static final String DATA_SCI = "DATA_SCI";
+
   @MRelation(role = RelationRole.TEMPLATE)
   private StetsonScript template;
   @MProperty
@@ -47,10 +52,17 @@ public class StetsonExecution extends Entity {
   private Entity pigExecution; // MD5(pig.script.id) from the job conf
   @MProperty
   private String link;
-  @MProperty
+
+  // Managed properties (register = true)
+  @MProperty(register = true, fieldType = CustomPropertyType.INTEGER)
   private int index;
-  @MProperty
+  // Must be an email address
+  @MProperty(register = true, pattern = "[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}")
   private String steward;
+  // Must be one of the specified values
+  @MProperty(register = true, fieldType = CustomPropertyType.ENUM,
+      values = {INFRA, DATA_ENG, DATA_SCI})
+  private String group;
 
   public StetsonExecution(String namespace) {
     // Because the namespace is given to input/output we ensure it
@@ -150,5 +162,13 @@ public class StetsonExecution extends Entity {
 
   public void setSteward(String steward) {
     this.steward = steward;
+  }
+
+  public String getGroup() {
+    return group;
+  }
+
+  public void setGroup(String group) {
+    this.group = group;
   }
 }

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/StetsonScript.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/managed/StetsonScript.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.examples.managed;
+
+import com.cloudera.nav.sdk.model.CustomIdGenerator;
+import com.cloudera.nav.sdk.model.SourceType;
+import com.cloudera.nav.sdk.model.annotations.MClass;
+import com.cloudera.nav.sdk.model.annotations.MRelation;
+import com.cloudera.nav.sdk.model.entities.EndPointProxy;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.cloudera.nav.sdk.model.entities.EntityType;
+import com.cloudera.nav.sdk.model.relations.RelationRole;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Represents a template defined by a script in a hypothetical custom DSL
+ */
+@MClass(model = "stetson_op")
+public class StetsonScript extends Entity {
+
+  @MRelation(role = RelationRole.PHYSICAL)
+  private EndPointProxy pigOperation;
+
+  public StetsonScript(String namespace) {
+    // Because the namespace is given to input/output we ensure it
+    // exists when it is used by adding it as a c'tor parameter
+    Preconditions.checkArgument(StringUtils.isNotEmpty(namespace));
+    setNamespace(namespace);
+  }
+
+  /**
+   * The script template is uniquely defined by the name and the owner
+   */
+  @Override
+  public String generateId() {
+    return CustomIdGenerator.generateIdentity(getNamespace(),
+        getPigOperation().getIdentity());
+  }
+
+  @Override
+  public SourceType getSourceType() {
+    return SourceType.SDK;
+  }
+
+  /**
+   * The StetsonScript represents a template and is therefore always an
+   * OPERATION entity
+   */
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.OPERATION;
+  }
+
+  /**
+   * The StetsonScript is linked to a PIG operation via a Logical-Physical
+   * relationship where the Pig operation is the PHYSICAL node
+   */
+  public Entity getPigOperation() {
+    return pigOperation;
+  }
+
+  public void setPigOperation(String pigOperationId) {
+    this.pigOperation = new EndPointProxy(pigOperationId, SourceType.PIG,
+        EntityType.OPERATION);
+  }
+}

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/schema/FireCircleSchemaCreator.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/schema/FireCircleSchemaCreator.java
@@ -43,8 +43,12 @@ public class FireCircleSchemaCreator {
     // initialize the plugin
     NavigatorPlugin plugin = NavigatorPlugin.fromConfigFile(args[0]);
 
+    // register models in package
+    plugin.registerModels("com.cloudera.nav.sdk.examples.schema");
+
     // get the HDFS source
-    Source fs = plugin.getClient().getOnlySource(SourceType.HDFS);
+    Source fs = plugin.getClient().getSourcesForType(SourceType.HDFS)
+        .iterator().next();
 
     // specify the HDFS directory that contains the data
     String path = args[1];

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHdfsFileTags.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHdfsFileTags.java
@@ -40,7 +40,9 @@ public class SetHdfsFileTags {
     // setup the plugin and api client
     NavigatorPlugin plugin = NavigatorPlugin.fromConfigFile(args[0]);
     NavApiCient client = plugin.getClient();
-    Source fs = client.getOnlySource(SourceType.HDFS);
+
+    // For the example we just take the first one without checking
+    Source fs = client.getSourcesForType(SourceType.HDFS).iterator().next();
 
     // send tags for multiple entities to Navigator
     HdfsEntity dir = new HdfsEntity("/user/hdfs", EntityType.DIRECTORY,

--- a/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHiveTags.java
+++ b/examples/src/main/java/com/cloudera/nav/sdk/examples/tags/SetHiveTags.java
@@ -48,7 +48,10 @@ public class SetHiveTags {
         "CONTAINS_SOME_SUPER_SECRET_STUFF"));
 
     NavApiCient client = plugin.getClient();
-    Source hive = client.getOnlySource(SourceType.HIVE);
+
+    // For the example we just take the first one without checking
+    Source hive = client.getSourcesForType(SourceType.HIVE).iterator().next();
+
     column.setSourceId(hive.getIdentity());
 
     // Write metadata

--- a/examples/src/main/resources/sample.conf
+++ b/examples/src/main/resources/sample.conf
@@ -1,16 +1,17 @@
 # this is the URL of the client application
 application_url=http://localhost
 
-file_format=JSON
-
 # Replace localhost:7187 with actual navigator URL
-navigator_url=http://localhost:7187/api/v8/
+navigator_url=http://localhost:7187
 
-# Replace localhost:7187 with actual navigator URL
-# duplicate to prepare for other methods of writing (e.g., staging in HDFS)
-metadata_parent_uri=http://localhost:7187/api/v8/metadata/plugin
+# Minimum is version 7 for publishing metadata to Navigator
+# Version 9 is minimum for typed custom property support
+navigator_api_version=9
 
+# Designator for client application
+# This will be used as the meta class package and custom property namespace
 namespace=example
 
+# Navigator username and password
 username=user
 password=password

--- a/model/src/main/java/com/cloudera/nav/sdk/model/MetadataModel.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/MetadataModel.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.model;
+
+import com.cloudera.nav.sdk.model.custom.CustomProperty;
+import com.cloudera.nav.sdk.model.custom.MetaClass;
+import com.cloudera.nav.sdk.model.custom.MetaClassPackage;
+import com.cloudera.nav.sdk.model.custom.Namespace;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Encapsulates relevant model information about a class annotated with @MClass
+ * so the model can be registered with the Navigator server
+ */
+public class MetadataModel {
+
+  private Set<MetaClassPackage> packages;
+  private Set<MetaClass> classes;
+  private Set<Namespace> namespaces;
+  private Set<CustomProperty> properties;
+  private Map<String, Set<String>> mappings;
+
+  public Set<MetaClassPackage> getPackages() {
+    return packages;
+  }
+
+  public void setPackages(Set<MetaClassPackage> packages) {
+    this.packages = packages;
+  }
+
+  public Set<MetaClass> getClasses() {
+    return classes;
+  }
+
+  public void setClasses(Set<MetaClass> classes) {
+    this.classes = classes;
+  }
+
+  public Set<Namespace> getNamespaces() {
+    return namespaces;
+  }
+
+  public void setNamespaces(Set<Namespace> namespaces) {
+    this.namespaces = namespaces;
+  }
+
+  public Set<CustomProperty> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Set<CustomProperty> properties) {
+    this.properties = properties;
+  }
+
+  /**
+   * Map<package.class, Set<namespace.property>>
+   */
+  public Map<String, Set<String>> getMappings() {
+    return mappings;
+  }
+
+  public void setMappings(Map<String, Set<String>> mappings) {
+    this.mappings = mappings;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/MetadataModelFactory.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/MetadataModelFactory.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.model;
+
+import com.cloudera.nav.sdk.model.annotations.MClass;
+import com.cloudera.nav.sdk.model.annotations.MProperty;
+import com.cloudera.nav.sdk.model.custom.CustomProperty;
+import com.cloudera.nav.sdk.model.custom.MetaClass;
+import com.cloudera.nav.sdk.model.custom.MetaClassPackage;
+import com.cloudera.nav.sdk.model.custom.Namespace;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.cloudera.nav.sdk.model.entities.TagChangeSet;
+import com.cloudera.nav.sdk.model.entities.UDPChangeSet;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Factory for generating MetadataModel instances from Entity sub-types
+ * annotated with @MClass
+ */
+public class MetadataModelFactory {
+
+  /**
+   * Create a MetadataModel from entity subclasses and a given namespace.
+   * For now we're assuming the given namespace is used for both the
+   * package of the meta-classes and the custom properties
+   *
+   * @param classes
+   * @param namespace
+   */
+  public MetadataModel newModel(
+      Collection<? extends Class<? extends Entity>> classes,
+      String namespace) {
+    MetadataModel model = new MetadataModel();
+    MetaClassPackage pkg = MetaClassPackage.newPackage(namespace);
+    model.setPackages(Sets.newHashSet(pkg));
+    Namespace ns = Namespace.newNamespace(namespace);
+    model.setNamespaces(Sets.newHashSet(ns));
+
+    Set<MetaClass> metaClasses = Sets.newHashSet();
+    Map<String, CustomProperty> mPropertyMap = Maps.newHashMap();
+    Map<String, Set<String>> mappings = Maps.newHashMap();
+    MetaClass mClass;
+    for (Class<? extends Entity> aClass : classes) {
+      MClass ann = aClass.getAnnotation(MClass.class);
+      mClass = MetaClass.newClass(pkg.getName(), ann.model());
+      metaClasses.add(mClass);
+
+      // get all @MProperty's (including inherited ones)
+      Map<Field, Method> properties = MClassUtil.getAnnotatedProperties(
+          aClass, MProperty.class);
+
+      Class<?> valueType;
+      Set<String> classMappings = Sets.newHashSet();
+      for (Map.Entry<Field, Method> entry : properties.entrySet()) {
+        valueType = entry.getKey().getType();
+        MProperty pAnn = entry.getKey().getAnnotation(MProperty.class);
+        if (valueType != UDPChangeSet.class && valueType != TagChangeSet.class
+            && pAnn.register()) {
+          String pName = StringUtils.isEmpty(pAnn.attribute()) ?
+              entry.getKey().getName() : pAnn.attribute();
+          boolean multiValued = Collection.class.isAssignableFrom(valueType);
+          if (checkExitingProperties(pName, pAnn, multiValued, mPropertyMap)) {
+            mPropertyMap.put(pName, CustomProperty.newProperty(ns.getName(),
+                pName, pAnn.fieldType(), multiValued, pAnn.values()));
+            classMappings.add(ns.getName() + "." + pName);
+          }
+        }
+      }
+      mappings.put(pkg.getName() + "." + mClass.getName(), classMappings);
+    }
+    model.setClasses(metaClasses);
+    model.setProperties(Sets.newHashSet(mPropertyMap.values()));
+    model.setMappings(mappings);
+    return model;
+  }
+
+  private boolean checkExitingProperties(String pName, MProperty ann,
+                                         boolean multiValued,
+                                         Map<String, CustomProperty> mProps) {
+    CustomProperty existing = mProps.get(pName);
+    if (existing != null) {
+      Preconditions.checkArgument(ann.register());
+      Preconditions.checkArgument(ann.fieldType() ==
+          existing.getPropertyType(),
+          String.format("Expecting %s to be of type %s, got %s instead",
+              pName, existing.getPropertyType(), ann.fieldType()));
+      // TODO validate type constraints
+      Preconditions.checkArgument(multiValued == existing.isMultiValued(),
+          String.format("Expecting %s to%sbe multi-valued", pName,
+              multiValued ? " " : " not "));
+    }
+    return existing == null;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/annotations/MProperty.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/annotations/MProperty.java
@@ -15,6 +15,8 @@
  */
 package com.cloudera.nav.sdk.model.annotations;
 
+import com.cloudera.nav.sdk.model.custom.CustomPropertyType;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -27,7 +29,41 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface MProperty {
 
+  /**
+   * Override for the property name
+   */
   String attribute() default "";
 
+  /**
+   * Client plugin will throw exception on write if value of property was null
+   */
   boolean required() default false;
+
+  /**
+   * If false then this property is treated as a dynamic text field. Currently
+   * this is opt-in because the custom metadata features in Navigator 2.6 are
+   * still experimental
+   */
+  boolean register() default false;
+
+  /**
+   * The field type for registered fields
+   */
+  CustomPropertyType fieldType() default CustomPropertyType.TEXT;
+
+  /**
+   * Validation for field values (server-side) if fieldType == TEXT
+   */
+  String pattern() default "";
+
+  /**
+   * Validation for field values (server-side) if fieldType == TEXT
+   * Default max length of 0 means no validation
+   */
+  int maxLength() default 0;
+
+  /**
+   * Allowed values if fieldType == ENUM
+   */
+  String[] values() default "";
 }

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/BaseModelObject.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/BaseModelObject.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+/**
+ * Base class for custom model objects including namespaces, classes, and
+ * properties
+ */
+public class BaseModelObject {
+
+  private String name;
+  private String displayName;
+  private String description;
+
+  /**
+   * The name for this model entity
+   */
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Text description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Human-friendly name for display purposes
+   */
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/CustomProperty.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/CustomProperty.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * A managed custom property which has a type and belong to a namespace and
+ * associated with metadata classes.
+ * Optionally a managed user-defined property can have validation
+ * constraints (max length and a regex pattern).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CustomProperty extends BaseModelObject {
+
+  public static CustomProperty newProperty(String namespace,
+                                           String name,
+                                           CustomPropertyType propertyType,
+                                           boolean multiValued, String[] values) {
+    CustomProperty prop = new CustomProperty();
+    prop.setNamespace(namespace);
+    prop.setName(name);
+    prop.setPropertyType(propertyType);
+    prop.setMultiValued(multiValued);
+    if (propertyType == CustomPropertyType.ENUM) {
+      Preconditions.checkNotNull(values);
+      Preconditions.checkArgument(values.length > 0);
+      prop.setEnumValues(Sets.newHashSet(values));
+    }
+    return prop;
+  }
+
+  private String namespace;
+  @JsonProperty("type")
+  private CustomPropertyType propertyType;
+  private boolean multiValued;
+  private Integer maxLength;
+  private String pattern;
+  private Set<String> enumValues;
+
+  /**
+   * Type of property values
+   */
+  public CustomPropertyType getPropertyType() {
+    return propertyType;
+  }
+
+  public void setPropertyType(CustomPropertyType propertyType) {
+    this.propertyType = propertyType;
+  }
+
+  /**
+   * Whether the property can contain multiple values
+   */
+  public boolean isMultiValued() {
+    return multiValued;
+  }
+
+  public void setMultiValued(boolean multiValued) {
+    this.multiValued = multiValued;
+  }
+
+  /**
+   * For String/Text properties only, the maximum number of characters for
+   * property values
+   */
+  public Integer getMaxLength() {
+    return maxLength;
+  }
+
+  public void setMaxLength(Integer maxLength) {
+    this.maxLength = maxLength;
+  }
+
+  /**
+   * For String/Text properties only, a regex pattern that property values must
+   * match
+   */
+  public String getPattern() {
+    return pattern;
+  }
+
+  public void setPattern(String pattern) {
+    this.pattern = pattern;
+  }
+
+  /**
+   * The namespace that this property belongs to
+   */
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public void setNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  /**
+   * Enum constants for enum properties
+   */
+  public Set<String> getEnumValues() {
+    return enumValues;
+  }
+
+  public void setEnumValues(Set<String> enumValues) {
+    this.enumValues = enumValues;
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * getNameHashCode() + getNamespaceHashCode();
+  }
+
+  private int getNameHashCode() {
+    return getName() == null ? "".hashCode() : getName().hashCode();
+  }
+
+  private int getNamespaceHashCode() {
+    return getNamespace() == null ? "".hashCode() : getNamespace().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other != null && other instanceof CustomProperty) {
+      CustomProperty o = (CustomProperty) other;
+      return StringUtils.equals(getName(), o.getName()) &&
+          StringUtils.equals(getNamespace(), o.getNamespace());
+    }
+    return false;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/CustomPropertyType.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/CustomPropertyType.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+/**
+ * Type info for the field. There is a known bug on the server side preventing
+ * successful processing of DATE fields so that's been disabled for now.
+ */
+public enum CustomPropertyType {
+  BOOLEAN(Boolean.class,
+      Sets.<Class<?>>newHashSet(Boolean.class, boolean.class)),
+  DOUBLE(Double.class,
+      Sets.<Class<?>>newHashSet(Double.class, double.class,
+          Float.class, float.class)),
+  FLOAT(Float.class,
+      Sets.<Class<?>>newHashSet(Float.class, float.class, double.class,
+          Double.class)),
+  INTEGER(Integer.class,
+      Sets.<Class<?>>newHashSet(Integer.class, int.class)),
+  LONG(Long.class,
+      Sets.<Class<?>>newHashSet(Long.class, long.class, Integer.class,
+          int.class)),
+  TEXT(String.class, Sets.<Class<?>>newHashSet(String.class)),
+  ENUM(Enum.class, Sets.<Class<?>>newHashSet(String.class, Enum.class));
+
+  private final Class<?> valueType;
+  private final Set<Class<?>> validInputTypes;
+
+  /**
+   * @param valueType
+   */
+  private CustomPropertyType(Class<?> valueType,
+                             Set<Class<?>> validInputTypes) {
+    Preconditions.checkArgument(validInputTypes.contains(valueType));
+    this.valueType = valueType;
+    this.validInputTypes = validInputTypes;
+  }
+
+  public Class<?> getValueType() {
+    return valueType;
+  }
+
+  public Set<Class<?>> getValidInputTypes() {
+    return validInputTypes;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/MetaClass.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/MetaClass.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Custom metadata model which belongs to either the default Navigator package
+ * or to a user-defined custom package. The pair of packageName and name must
+ * be unique for a MetaClass
+ *
+ * New instances should be created via the newClass static factory method so
+ * that we can make it harder to miss required properties at compile time
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetaClass extends BaseModelObject {
+
+  public static MetaClass newClass(String packageName, String name) {
+    Preconditions.checkArgument(StringUtils.isNotEmpty(packageName));
+    Preconditions.checkArgument(StringUtils.isNotEmpty(name));
+    MetaClass metaClass = new MetaClass();
+    metaClass.setPackageName(packageName);
+    metaClass.setName(name);
+    return metaClass;
+  }
+
+  private String packageName;
+
+  /**
+   * The namespace for this model
+   */
+  public String getPackageName() {
+    return packageName;
+  }
+
+  public void setPackageName(String packageName) {
+    this.packageName = packageName;
+  }
+
+  @Override
+  public int hashCode() {
+    return getNameHashCode() * 31 + getPackageNameHashCode();
+  }
+
+  private int getNameHashCode() {
+    return getName() == null ? "".hashCode() : getName().hashCode();
+  }
+
+  private int getPackageNameHashCode() {
+    return getPackageName() == null ? "".hashCode() :
+        getPackageName().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other != null && other instanceof MetaClass) {
+      MetaClass o = (MetaClass) other;
+      return StringUtils.equals(getName(), o.getName()) &&
+          StringUtils.equals(getPackageName(), o.getPackageName());
+    }
+    return false;
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/MetaClassPackage.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/MetaClassPackage.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Defines groups of MetaClasses
+ *
+ * New instances should be created via the newPackage static factory method so
+ * that we can make it harder to miss required properties at compile time
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MetaClassPackage extends BaseModelObject {
+
+  public static final String DEFAULT_PACKAGE_NAME = "nav";
+
+  public static MetaClassPackage newPackage(String name) {
+    Preconditions.checkArgument(StringUtils.isNotEmpty(name));
+    MetaClassPackage pkg = new MetaClassPackage();
+    pkg.setName(name);
+    return pkg;
+  }
+
+  private boolean external;
+
+  public boolean isDefaultPackage() {
+    return StringUtils.equals(DEFAULT_PACKAGE_NAME, getName());
+  }
+
+  /**
+   * Whether this namespace is for an external third-party application
+   */
+  public boolean isExternal() {
+    return external;
+  }
+
+  public void setExternal(boolean external) {
+    this.external = external;
+  }
+
+  @Override
+  public int hashCode() {
+    return getName() == null ? "".hashCode() : getName().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other != null &&
+        other instanceof MetaClassPackage &&
+        getName() != null && getName().equals(
+        ((MetaClassPackage) other).getName());
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/custom/Namespace.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/custom/Namespace.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.nav.sdk.model.custom;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.google.common.base.Preconditions;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Defines groups of custom metadata properties
+ *
+ * New instances should be created via the newNamespace static factory method so
+ * that we can make it harder to miss required properties at compile time
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Namespace extends BaseModelObject {
+
+  public static final String DEFAULT_NAMESPACE_NAME = "nav";
+
+  public static Namespace newNamespace(String name) {
+    Preconditions.checkArgument(StringUtils.isNotEmpty(name));
+    Namespace ns = new Namespace();
+    ns.setName(name);
+    return ns;
+  }
+
+  private boolean external;
+
+  public boolean isDefaultNamespace() {
+    return StringUtils.equals(DEFAULT_NAMESPACE_NAME, getName());
+  }
+
+  /**
+   * Whether this namespace is for an external third-party application
+   */
+  public boolean isExternal() {
+    return external;
+  }
+
+  public void setExternal(boolean external) {
+    this.external = external;
+  }
+
+  @Override
+  public int hashCode() {
+    return getName() == null ? "".hashCode() : getName().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other != null &&
+        other instanceof Namespace &&
+        getName() != null && getName().equals(
+        ((Namespace) other).getName());
+  }
+}

--- a/model/src/main/java/com/cloudera/nav/sdk/model/entities/Entity.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/entities/Entity.java
@@ -57,7 +57,7 @@ public abstract class Entity {
   @MProperty
   private boolean deleted;
   @MProperty
-  private Long deletionTime;
+  private Long deleteTime;
   @MProperty
   private TagChangeSet tags;
   @MProperty
@@ -199,16 +199,16 @@ public abstract class Entity {
    * @return deletion time in milliseconds since epoch if the custom entity
    *         has been deleted and null otherwise.
    */
-  public Long getDeletionTime() {
-    return deletionTime;
+  public Long getDeleteTime() {
+    return deleteTime;
   }
 
   /**
    * Set deletion time for the custom entity
-   * @param deletionTime
+   * @param deleteTime
    */
-  public void setDeletionTime(Long deletionTime) {
-    this.deletionTime = deletionTime;
+  public void setDeleteTime(Long deleteTime) {
+    this.deleteTime = deleteTime;
   }
 
   public Instant getCreated() {

--- a/model/src/main/java/com/cloudera/nav/sdk/model/entities/UDPChangeSet.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/entities/UDPChangeSet.java
@@ -132,4 +132,12 @@ public class UDPChangeSet {
     }
     this.removeProperties = removeProperties;
   }
+
+  public static UDPChangeSet copyOf(UDPChangeSet properties) {
+    UDPChangeSet rs = new UDPChangeSet();
+    rs.overrideProperties = Maps.newHashMap(properties.getOverrideProperties());
+    rs.newProperties = Maps.newHashMap(properties.getNewProperties());
+    rs.removeProperties = Sets.newHashSet(properties.getRemoveProperties());
+    return rs;
+  }
 }

--- a/model/src/test/java/com/cloudera/nav/sdk/model/MetadataModelTest.java
+++ b/model/src/test/java/com/cloudera/nav/sdk/model/MetadataModelTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2015 Cloudera, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudera.nav.sdk.model;
+
+import static org.junit.Assert.*;
+
+import com.cloudera.nav.sdk.model.annotations.MClass;
+import com.cloudera.nav.sdk.model.annotations.MProperty;
+import com.cloudera.nav.sdk.model.entities.Dataset;
+import com.cloudera.nav.sdk.model.entities.TagChangeSet;
+import com.cloudera.nav.sdk.model.entities.UDPChangeSet;
+import com.google.common.collect.Iterables;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+
+import org.junit.*;
+
+/**
+ * Test MetadataModel and factory class
+ */
+public class MetadataModelTest {
+
+  private MetadataModelFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = new MetadataModelFactory();
+  }
+
+  @Test
+  public void testFactory() {
+    MetadataModel model = factory.newModel(Collections.singleton(
+        TestDataset.class), "test");
+    assertEquals("test", Iterables.getOnlyElement(model.getNamespaces())
+        .getName());
+    assertEquals("test", Iterables.getOnlyElement(model.getPackages())
+        .getName());
+    assertEquals("dataset", Iterables.getOnlyElement(model.getClasses())
+        .getName());
+    int fieldCount = countMPropertyFields(TestDataset.class);
+    assertEquals(fieldCount, model.getProperties().size());
+  }
+
+  private int countMPropertyFields(Class<?> aClass) {
+    int fieldCount = 0;
+    if (aClass == null) {
+      return 0;
+    }
+    for (Field field : aClass.getDeclaredFields()) {
+      MProperty ann = field.getAnnotation(MProperty.class);
+      if (ann != null && ann.register() &&
+          field.getType() != UDPChangeSet.class &&
+          field.getType() != TagChangeSet.class) {
+        fieldCount++;
+      }
+    }
+    return fieldCount + countMPropertyFields(aClass.getSuperclass());
+  }
+
+  @MClass(model="dataset")
+  private static class TestDataset extends Dataset {
+    @Override
+    public String generateId() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/release_notes/v2.0.md
+++ b/release_notes/v2.0.md
@@ -1,0 +1,33 @@
+Cloudera Navigator SDK Version 2.0 Release Notes
+==================================================
+
+This is the second major release of the Cloudera Navigator SDK which adds the
+ability to create manage metadata fields new to Cloudera Navigator 2.6.0.
+Managed metadata is a more organized way to extend metadata properties collected
+by Navigator. Managed metadata properties must be declared with a type
+constraint on the value(s), must belong to a namespace, and can be associated
+with 0 or more metadata classes.
+
+Creating Managed Metadata Models
+--------------------------------
+
+The SDK client is configured with a namespace that's used for all declared
+managed metadata properties. It is also the package name for all custom metadata
+classes. Just as a reminder, a custom metadata class can be created by
+subclassing Entity with an @MClass annotation.
+
+New metadata properties for custom metadata classes are created using the
+@MProperty annotation. In this new version of the SDK, we've added new
+attributes to the annotation to make it easier to register managed metadata
+properties. In order to create a managed property, set the `register` attribute
+to `true`. You can then set `fieldType` (default `TEXT`), `pattern` for regex
+matching, `maxLength` for `TEXT` fields, or an array of `values` for `ENUM`
+properties. The examples have been updated to demonstrate this new capability.
+
+API Client
+----------
+
+The minimum API version that supports managed metadata models is v9.
+Previously, the Navigator URL is specified in full including the api version.
+Now the API version must be specified explicitly as the configuration variable
+`navigator_api_version`.


### PR DESCRIPTION
To support type custom fields and richer metadata modeling, we implement
the registerModels feature of the SDK to convert @MClass models into JSON
to be registered with the server. We're using the new custom property feature
in Navigator 2.6 to create managed custom properties that have a type and 
allow validation constraints to be specified. These properties belong to namespaces 
and are associated with various meta-classes (i.e., hdfs entities,
Hive tables, etc).

Closes #52 
Closes #53 

TODO:

- [x] Fix hard coded namespace
- [x] Make API version an explicit config variable
- [x] Fix broken tests
- [x] Clean up examples
- [x] documentation