### PR TITLE
Add S3 source

### DIFF
--- a/model/src/main/java/com/cloudera/nav/sdk/model/SourceType.java
+++ b/model/src/main/java/com/cloudera/nav/sdk/model/SourceType.java
@@ -19,5 +19,5 @@ package com.cloudera.nav.sdk.model;
  * Constant string names for default Source types
  */
 public enum SourceType {
-  NONE, MAPREDUCE, YARN, HDFS, HIVE, PIG, IMPALA, OOZIE, SDK, SQOOP, SPARK
+  NONE, MAPREDUCE, YARN, HDFS, HIVE, PIG, IMPALA, OOZIE, SDK, SQOOP, SPARK, S3
 }


### PR DESCRIPTION
Required for use with Navigator 2.9

Without this change we get the below exception running included examples:
```
2017-03-08 16:01:49,447 DEBUG [main:client.RestTemplate@92] Reading [class [Lcom.cloudera.nav.sdk.client.SourceAttrs;] as "application/json" using [org.springframework.http.converter.json.MappingJackson2HttpMessageConverter@c730b35]
Exception in thread "main" org.springframework.http.converter.HttpMessageNotReadableException: Could not read JSON: Can not construct instance of com.cloudera.nav.sdk.model.SourceType from String value 'S3': value not one of declared Enum instance names
```